### PR TITLE
Approving PR loaded segmentations now are now directly erasable #153

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2418,9 +2418,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onPushLassoPaint(self):
         self.startTimerForActions()
         self.previousAction = 'segmentation'
-
         self.ensure_active_segment_is_selected()
-
         self.segmentEditorWidget.setActiveEffectByName("Scissors")
         self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
         effect = self.segmentEditorWidget.activeEffect()
@@ -2431,12 +2429,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onPushButton_Paint(self):
         self.startTimerForActions()
         self.previousAction = 'segmentation'
-
-        # selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(self.config_yaml["labels"][self.current_label_index]['name'])
-        # self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
-
         self.ensure_active_segment_is_selected()
-
         self.segmentEditorWidget.setActiveEffectByName("Paint")
         # Note it seems that sometimes you need to activate the effect first with :
         # Assign effect to the segmentEditorWidget using the active effect
@@ -2451,13 +2444,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.segmentEditorNode.SetSourceVolumeIntensityMaskRange(self.LB_HU, self.UB_HU)
         self.segmentEditorNode.SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteAllSegments)
 
+  @enter_function
   def ensure_active_segment_is_selected(self):
       # Make sure a valid segment is selected
       selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(
           self.config_yaml["labels"][self.current_label_index]['name']
       )
       self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
-
 
   def toggleFillButton(self):
       self.startTimerForActions()
@@ -2507,20 +2500,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.startTimerForActions()
       self.previousAction = 'segmentation'
 
-      # # Make sure a valid segment is selected
-      # selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(
-      #     self.config_yaml["labels"][self.current_label_index]['name']
-      # )
-      # self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
+      # Make sure a valid segment is selected
       self.ensure_active_segment_is_selected()
-
 
       self.segmentEditorWidget.setActiveEffectByName("Erase")
       # Note it seems that sometimes you need to activate the effect first with :
       # Assign effect to the segmentEditorWidget using the active effect
       self.effect = self.segmentEditorWidget.activeEffect()
-      # self.effect.setParameter("EraseAllSegments", "1") #erase all visible active segments
-
       # Seems that you need to activate the effect to see it in Slicer
       self.effect.activate()
       self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
@@ -2530,9 +2516,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Smoothing
       self.startTimerForActions()
       self.previousAction = 'segmentation'
-
       self.ensure_active_segment_is_selected()
-
       self.segmentEditorWidget = slicer.modules.segmenteditor.widgetRepresentation().self().editor
       self.segmentEditorWidget.setActiveEffectByName("Smoothing")
       effect = self.segmentEditorWidget.activeEffect()

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2418,6 +2418,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onPushLassoPaint(self):
         self.startTimerForActions()
         self.previousAction = 'segmentation'
+
+        self.ensure_active_segment_is_selected()
+
         self.segmentEditorWidget.setActiveEffectByName("Scissors")
         self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
         effect = self.segmentEditorWidget.activeEffect()
@@ -2428,8 +2431,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onPushButton_Paint(self):
         self.startTimerForActions()
         self.previousAction = 'segmentation'
-        selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(self.config_yaml["labels"][self.current_label_index]['name'])
-        self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
+
+        # selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(self.config_yaml["labels"][self.current_label_index]['name'])
+        # self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
+
+        self.ensure_active_segment_is_selected()
+
         self.segmentEditorWidget.setActiveEffectByName("Paint")
         # Note it seems that sometimes you need to activate the effect first with :
         # Assign effect to the segmentEditorWidget using the active effect
@@ -2443,6 +2450,14 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.set_master_volume_intensity_mask_according_to_modality()
         self.segmentEditorNode.SetSourceVolumeIntensityMaskRange(self.LB_HU, self.UB_HU)
         self.segmentEditorNode.SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteAllSegments)
+
+  def ensure_active_segment_is_selected(self):
+      # Make sure a valid segment is selected
+      selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(
+          self.config_yaml["labels"][self.current_label_index]['name']
+      )
+      self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
+
 
   def toggleFillButton(self):
       self.startTimerForActions()
@@ -2491,10 +2506,21 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onPushButton_Erase(self):
       self.startTimerForActions()
       self.previousAction = 'segmentation'
+
+      # # Make sure a valid segment is selected
+      # selected_segment_id = self.segmentationNode.GetSegmentation().GetSegmentIdBySegmentName(
+      #     self.config_yaml["labels"][self.current_label_index]['name']
+      # )
+      # self.segmentEditorNode.SetSelectedSegmentID(selected_segment_id)
+      self.ensure_active_segment_is_selected()
+
+
       self.segmentEditorWidget.setActiveEffectByName("Erase")
       # Note it seems that sometimes you need to activate the effect first with :
       # Assign effect to the segmentEditorWidget using the active effect
       self.effect = self.segmentEditorWidget.activeEffect()
+      # self.effect.setParameter("EraseAllSegments", "1") #erase all visible active segments
+
       # Seems that you need to activate the effect to see it in Slicer
       self.effect.activate()
       self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
@@ -2504,6 +2530,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Smoothing
       self.startTimerForActions()
       self.previousAction = 'segmentation'
+
+      self.ensure_active_segment_is_selected()
+
       self.segmentEditorWidget = slicer.modules.segmenteditor.widgetRepresentation().self().editor
       self.segmentEditorWidget.setActiveEffectByName("Smoothing")
       effect = self.segmentEditorWidget.activeEffect()

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -79,20 +79,20 @@ is_keyboard_shortcuts_requested: true
 is_mouse_shortcuts_requested: true
 is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
-keep_working_list: false
+keep_working_list: true
 labels:
-- color_b: 10
+- color_b: 255
   color_g: 10
   color_r: 255
   lower_bound_HU: 30
-  name: ICH
+  name: sc_seg
   upper_bound_HU: 90
   value: 1
-- color_b: 70
-  color_g: 230
-  color_r: 230
+- color_b: 240
+  color_g: 111
+  color_r: 111
   lower_bound_HU: 30
-  name: IVH
+  name: edema
   upper_bound_HU: 90
   value: 2
 modality: MRI

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -81,18 +81,18 @@ is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
 keep_working_list: true
 labels:
-- color_b: 255
+- color_b: 10
   color_g: 10
   color_r: 255
   lower_bound_HU: 30
-  name: sc_seg
+  name: ICH
   upper_bound_HU: 90
   value: 1
-- color_b: 240
-  color_g: 111
-  color_r: 111
+- color_b: 70
+  color_g: 230
+  color_r: 230
   lower_bound_HU: 30
-  name: edema
+  name: IVH
   upper_bound_HU: 90
   value: 2
 modality: MRI


### PR DESCRIPTION
Approving PR (with corrections directly done) from @AcastaPaloma that was named: loaded segmentations now are now directly erasable #153

Also, fixed the same problem for other buttons (lasso, smooth margins).

The PR : https://github.com/neuropoly/slicercart/pull/153 will be closed.

The reason a new PR is done is from the renaming of the repository between the PR and its approval.