### PR TITLE
fixes issue #167 Keyboard shortcut are not activated when the configuration window is not used

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -201,8 +201,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.ToggleSegmentation.setStyleSheet(f"background-color : {self.color_inactive}")
 
     self.ui.lcdNumber.setStyleSheet("background-color : black")
-    
+
     self.MostRecentPausedCasePath = ""
+
+    # Ensure keyboard shortcut (at least from the last configuration) work
+    # at startup
+    self.set_keyboard_shortcuts()
 
   @enter_function
   def set_classification_version_labels(self, classif_label):
@@ -307,17 +311,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.pushDefaultMin.setVisible(False)
         self.ui.pushDefaultMax.setVisible(False)
 
-    if self.config_yaml['is_keyboard_shortcuts_requested']:
-        for i in self.config_yaml["KEYBOARD_SHORTCUTS"]:
-
-            shortcutKey = i.get("shortcut")
-            callback_name = i.get("callback")
-            button_name = i.get("button")
-
-            button = getattr(self.ui, button_name)
-            callback = getattr(self, callback_name)
-
-            self.connectShortcut(shortcutKey, button, callback)
+    self.set_keyboard_shortcuts()
 
     if self.config_yaml['is_display_timer_requested']:
         self.ui.lcdNumber.setStyleSheet("background-color : black")
@@ -335,6 +329,19 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         slicer.app.layoutManager().setLayout(
             slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpGreenSliceView)
 
+
+  @enter_function
+  def set_keyboard_shortcuts(self):
+      if self.config_yaml['is_keyboard_shortcuts_requested']:
+          for i in self.config_yaml["KEYBOARD_SHORTCUTS"]:
+              shortcutKey = i.get("shortcut")
+              callback_name = i.get("callback")
+              button_name = i.get("button")
+
+              button = getattr(self.ui, button_name)
+              callback = getattr(self, callback_name)
+
+              self.connectShortcut(shortcutKey, button, callback)
 
   @enter_function
   def set_segmentation_config_ui(self):


### PR DESCRIPTION
This PR enables to use keyboard shortcut even if the configuration window has not been used for setting. up a new configuration.

How to test?
1. Open Slicer and SlicerCART
2.  Select directly volume and output folder, then enter annotator name, degre and revision step.
3. Do segmentation
4. Use keyboard shortcut e.g. s for saving and see if it works (for saving, keyboard shortcut is by default s)