### PR TITLE
Fixes https://github.com/neuropoly/slicercart/issues/178

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2942,7 +2942,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             Debug.print(self, 'MODALITY==CT')
             Vol_displayNode.SetWindow(ConfigPath.CT_WINDOW_WIDTH)
             Vol_displayNode.SetLevel(ConfigPath.CT_WINDOW_LEVEL)
-        Vol_displayNode.SetInterpolate(INTERPOLATE_VALUE)
+        Vol_displayNode.SetInterpolate(ConfigPath.INTERPOLATE_VALUE)
 
         self.segmentEditorWidget = (
             slicer.modules.segmenteditor.widgetRepresentation().self().editor)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -245,6 +245,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.disablePauseTimerButton()
         self.disableSegmentAndPaintButtons()
         self.ui.pushButton_Interpolate.setEnabled(False)
+        print('CongiPath interpoalte initila', ConfigPath.INTERPOLATE_VALUE)
+        self.adjust_interpolate_button_color(ConfigPath.INTERPOLATE_VALUE)
         self.ui.SaveSegmentationButton.setEnabled(False)
 
         self.enableStartTimerButton()
@@ -409,6 +411,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.config_yaml['slice_view_color'] == "Green":
             slicer.app.layoutManager().setLayout(
                 slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpGreenSliceView)
+
+        self.adjust_interpolate_button_color(ConfigPath.INTERPOLATE_VALUE)
 
     @enter_function
     def set_keyboard_shortcuts(self):
@@ -1148,10 +1152,32 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         Args:.
         """
-        global INTERPOLATE_VALUE
-        INTERPOLATE_VALUE = 1 - INTERPOLATE_VALUE  # toggle
 
+        # global INTERPOLATE_VALUE
+        # INTERPOLATE_VALUE = 1 - INTERPOLATE_VALUE  # toggle
+        # INTERPOLATE_VALUE = 1 - ConfigPath.INTERPOLATE_VALUE
+        print('interpolate value before', ConfigPath.INTERPOLATE_VALUE)
+        INTERPOLATE_VALUE = not ConfigPath.INTERPOLATE_VALUE
+        ConfigPath.set_interpolate_value(INTERPOLATE_VALUE)
+        print('interpolate value after', ConfigPath.INTERPOLATE_VALUE)
+
+        self.adjust_interpolate_button_color(INTERPOLATE_VALUE)
         self.VolumeNode.GetDisplayNode().SetInterpolate(INTERPOLATE_VALUE)
+
+    @enter_function
+    def adjust_interpolate_button_color(self, value):
+        """
+        Adjust the volume interpolation state to true or false
+
+        Args:
+            value: true (interpolated volume) or false (raw image)
+        """
+        if value:
+            self.ui.pushButton_Interpolate.setStyleSheet(
+                f"color: {self.color_active};")
+        else:
+            self.ui.pushButton_Interpolate.setStyleSheet(
+                f"color: {self.color_inactive};")
 
     @enter_function
     def onPreviousButton(self):

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -245,7 +245,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.disablePauseTimerButton()
         self.disableSegmentAndPaintButtons()
         self.ui.pushButton_Interpolate.setEnabled(False)
-        print('CongiPath interpoalte initila', ConfigPath.INTERPOLATE_VALUE)
         self.adjust_interpolate_button_color(ConfigPath.INTERPOLATE_VALUE)
         self.ui.SaveSegmentationButton.setEnabled(False)
 
@@ -1153,13 +1152,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         Args:.
         """
 
-        # global INTERPOLATE_VALUE
-        # INTERPOLATE_VALUE = 1 - INTERPOLATE_VALUE  # toggle
-        # INTERPOLATE_VALUE = 1 - ConfigPath.INTERPOLATE_VALUE
-        print('interpolate value before', ConfigPath.INTERPOLATE_VALUE)
         INTERPOLATE_VALUE = not ConfigPath.INTERPOLATE_VALUE
         ConfigPath.set_interpolate_value(INTERPOLATE_VALUE)
-        print('interpolate value after', ConfigPath.INTERPOLATE_VALUE)
 
         self.adjust_interpolate_button_color(INTERPOLATE_VALUE)
         self.VolumeNode.GetDisplayNode().SetInterpolate(INTERPOLATE_VALUE)

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -72,7 +72,7 @@ freetextboxes:
   other_comments: Comments
 impose_bids_format: false
 input_filetype: '*.nii.gz'
-interpolate_value: true
+interpolate_value: false
 is_classification_requested: true
 is_display_timer_requested: false
 is_keyboard_shortcuts_requested: true

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -72,7 +72,7 @@ freetextboxes:
   other_comments: Comments
 impose_bids_format: false
 input_filetype: '*.nii.gz'
-interpolate_value: 0
+interpolate_value: true
 is_classification_requested: true
 is_display_timer_requested: false
 is_keyboard_shortcuts_requested: true

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -775,8 +775,6 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         self.config_yaml['KEYBOARD_SHORTCUTS'][6][
             'shortcut'] = self.interpolate_ks_selected
 
-        print('interpolate state', self.config_yaml['interpolate_value'])
-
         ConfigPath.write_config_file()
         self.config_yaml = ConfigPath.open_project_config_file()
 

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -624,9 +624,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         Args:
         """
         if self.interpolate_combobox.currentText == 'Yes':
-            self.interpolate_selected = 1
+            self.interpolate_selected = True
         else:
-            self.interpolate_selected = 0
+            self.interpolate_selected = False
 
     @enter_function
     def update_initial_view(self):
@@ -774,6 +774,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
             'shortcut'] = self.remove_small_holes_ks_selected
         self.config_yaml['KEYBOARD_SHORTCUTS'][6][
             'shortcut'] = self.interpolate_ks_selected
+
+        print('interpolate state', self.config_yaml['interpolate_value'])
 
         ConfigPath.write_config_file()
         self.config_yaml = ConfigPath.open_project_config_file()

--- a/SlicerCART/src/utils/ConfigPath.py
+++ b/SlicerCART/src/utils/ConfigPath.py
@@ -400,6 +400,16 @@ class ConfigPath():
         """
         self.flag_remove_combobox = value
 
+    @enter_function
+    def set_interpolate_value(self, value):
+        """
+        set the interpolation state for rendered volumes.
+
+        Args:
+            value: true (interpolation) or false (raw image, not interpolated)
+        """
+        self.INTERPOLATE_VALUE = value
+
 
 # Creating an instance of ConfigPath. This ensures that all the same
 # config values will be used in the different files/modules.


### PR DESCRIPTION
This PR:

- Fixes the interpolate toggle button in the UI (if interpolation state is false, the foreground color is the inactive color and if the interpolation state is true, the foreground color is the active color)
- Now read write true false value in the configuration file instead of 0 and 1 (more consistent with other config file values)