### PR TITLE
PATCH: GitHub deployment CI was publishing the wrong directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Directory below is built in the prior step
-          publish_dir: ./SlicerCART/docs/_build
+          publish_dir: ./SlicerCART/docs/_build/html
           publish_branch: gh-pages
           force_orphan: true
 
@@ -59,4 +59,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built_website
-          path: ./SlicerCART/docs/_build
+          path: ./SlicerCART/docs/_build/html


### PR DESCRIPTION
As the title says; the newer versions of Sphynx builds the HTML in a sub-directory of build for some reason. 