### PR TITLE
Fixes issue 216 about 3D Slicer version 5.8.1 compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Directory below is built in the prior step
-          publish_dir: ./SlicerCART/docs/_build
+          publish_dir: ./SlicerCART/docs/_build/html
           publish_branch: gh-pages
           force_orphan: true
 
@@ -59,4 +59,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built_website
-          path: ./SlicerCART/docs/_build
+          path: ./SlicerCART/docs/_build/html

--- a/SlicerCART/docs/_source/installation.rst
+++ b/SlicerCART/docs/_source/installation.rst
@@ -8,8 +8,7 @@ Prerequisites
 
  **3D Slicer**
    
-   SlicerCART is a module for 3D Slicer. You need to have 3D Slicer
-installed on your system:
+   SlicerCART is a module for 3D Slicer. You need to have 3D Slicer installed on your system:
 
    * Download 3D Slicer from the `official website <https://download.slicer.org/>`_ (version 5.6.2 on macOS is recommended)
    * Launch 3D Slicer to verify the installation

--- a/SlicerCART/docs/_source/installation.rst
+++ b/SlicerCART/docs/_source/installation.rst
@@ -8,7 +8,7 @@ Prerequisites
 
  **3D Slicer**
    
-   SlicerCARTtest is a module for 3D Slicer. You need to have 3D Slicer
+   SlicerCART is a module for 3D Slicer. You need to have 3D Slicer
 installed on your system:
 
    * Download 3D Slicer from the `official website <https://download.slicer.org/>`_ (version 5.6.2 on macOS is recommended)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2226,6 +2226,23 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         return is_valid
 
     @enter_function
+    def re_order_segments(self, segmentation_node):
+        # Ensure final segment order matches the order in config_yaml["labels"]
+        ordered_segment_ids = []
+        segmentation = segmentation_node.GetSegmentation()
+
+        # First, collect current ID for each name in the right order
+        for label in self.config_yaml["labels"]:
+            segment_id = segmentation.GetSegmentIdBySegmentName(label["name"])
+            if segment_id:
+                ordered_segment_ids.append(segment_id)
+
+        # Apply reordering
+        segmentation.ReorderSegments(ordered_segment_ids)
+        print(
+            f"Segments reordered according to config_yaml: {ordered_segment_ids}")
+
+    @enter_function
     def saveNrrdSegmentation(self, currentSegmentationVersion):
         """
         Note that NRRD segmentation save in uint8 by default in contrast to
@@ -3312,6 +3329,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                                     label["color_b"],
                                     label["lower_bound_HU"],
                                     label["upper_bound_HU"])
+
+        self.re_order_segments(segmentation_node)
 
 
 

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -94,6 +94,13 @@ labels:
   name: IVH
   upper_bound_HU: 90
   value: 2
+- color_b: 22
+  color_g: 222
+  color_r: 22
+  lower_bound_HU: 30
+  name: test
+  upper_bound_HU: 90
+  value: 3
 modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,7 +24,6 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 checkboxes:
-  Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
   EDH_checkbox: EDH
@@ -43,6 +42,7 @@ checkboxes:
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
+  test: Test
 comboboxes:
   v01:
     atrophy:
@@ -60,13 +60,26 @@ comboboxes:
       wmc_moderate: Moderate
       wmc_none: None
       wmc_severe: Severe
+  v02:
+    test:
+      '22': '22'
+      '222': '222'
+    ventricular_size:
+      ventricular_size_mild: Mild
+      ventricular_size_moderate: Moderate
+      ventricular_size_normal: Normal/proportional
+      ventricular_size_severe: Severe
+    white_matter_changes:
+      wmc_mild: Mild
+      wmc_moderate: Moderate
+      wmc_none: None
+      wmc_severe: Severe
 ct_window_level: 45
 ct_window_width: 85
 default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
-  cheese: Cheese
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false
@@ -80,30 +93,23 @@ is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
 keep_working_list: true
 labels:
-- color_b: 10
-  color_g: 10
-  color_r: 255
+- color_b: 255
+  color_g: 255
+  color_r: 0
   lower_bound_HU: 30
-  name: ICH
+  name: edema
   upper_bound_HU: 90
   value: 1
-- color_b: 70
-  color_g: 230
-  color_r: 230
+- color_b: 240
+  color_g: 0
+  color_r: 2
   lower_bound_HU: 30
-  name: IVH
+  name: george
   upper_bound_HU: 90
   value: 2
-- color_b: 22
-  color_g: 222
-  color_r: 22
-  lower_bound_HU: 30
-  name: test
-  upper_bound_HU: 90
-  value: 3
 modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true
-slice_view_color: Yellow
+slice_view_color: Red
 working_list_filename: working_list.yaml

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -26,7 +26,6 @@ KEYBOARD_SHORTCUTS:
 checkboxes:
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
-  EDH_checkbox: EDH
   EVD_checkbox: EVD
   ICH_checkbox: ICH
   IVH_checkbox: IVH
@@ -74,6 +73,20 @@ comboboxes:
       wmc_moderate: Moderate
       wmc_none: None
       wmc_severe: Severe
+  v03:
+    test:
+      '111': '111'
+      '22': '22'
+    ventricular_size:
+      ventricular_size_mild: Mild
+      ventricular_size_moderate: Moderate
+      ventricular_size_normal: Normal/proportional
+      ventricular_size_severe: Severe
+    white_matter_changes:
+      wmc_mild: Mild
+      wmc_moderate: Moderate
+      wmc_none: None
+      wmc_severe: Severe
 ct_window_level: 45
 ct_window_width: 85
 default_segmentation_directory: ''
@@ -100,16 +113,23 @@ labels:
   name: edema
   upper_bound_HU: 90
   value: 1
-- color_b: 240
-  color_g: 0
-  color_r: 2
+- color_b: 255
+  color_g: 10
+  color_r: 10
   lower_bound_HU: 30
-  name: george
+  name: hemorrhage
   upper_bound_HU: 90
   value: 2
+- color_b: 22
+  color_g: 222
+  color_r: 22
+  lower_bound_HU: 30
+  name: test_sc
+  upper_bound_HU: 90
+  value: 3
 modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true
-slice_view_color: Red
+slice_view_color: Yellow
 working_list_filename: working_list.yaml

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,8 +24,10 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 checkboxes:
+  Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
+  EDH_checkbox: EDH
   EVD_checkbox: EVD
   ICH_checkbox: ICH
   IVH_checkbox: IVH
@@ -41,7 +43,6 @@ checkboxes:
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
-  test: Test
 comboboxes:
   v01:
     atrophy:
@@ -59,40 +60,13 @@ comboboxes:
       wmc_moderate: Moderate
       wmc_none: None
       wmc_severe: Severe
-  v02:
-    test:
-      '22': '22'
-      '222': '222'
-    ventricular_size:
-      ventricular_size_mild: Mild
-      ventricular_size_moderate: Moderate
-      ventricular_size_normal: Normal/proportional
-      ventricular_size_severe: Severe
-    white_matter_changes:
-      wmc_mild: Mild
-      wmc_moderate: Moderate
-      wmc_none: None
-      wmc_severe: Severe
-  v03:
-    test:
-      '111': '111'
-      '22': '22'
-    ventricular_size:
-      ventricular_size_mild: Mild
-      ventricular_size_moderate: Moderate
-      ventricular_size_normal: Normal/proportional
-      ventricular_size_severe: Severe
-    white_matter_changes:
-      wmc_mild: Mild
-      wmc_moderate: Moderate
-      wmc_none: None
-      wmc_severe: Severe
 ct_window_level: 45
 ct_window_width: 85
 default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
+  cheese: Cheese
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false
@@ -106,27 +80,20 @@ is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
 keep_working_list: true
 labels:
-- color_b: 255
-  color_g: 255
-  color_r: 0
+- color_b: 10
+  color_g: 10
+  color_r: 255
   lower_bound_HU: 30
-  name: edema
+  name: ICH
   upper_bound_HU: 90
   value: 1
-- color_b: 255
-  color_g: 10
-  color_r: 10
+- color_b: 70
+  color_g: 230
+  color_r: 230
   lower_bound_HU: 30
-  name: hemorrhage
+  name: IVH
   upper_bound_HU: 90
   value: 2
-- color_b: 22
-  color_g: 222
-  color_r: 22
-  lower_bound_HU: 30
-  name: test_sc
-  upper_bound_HU: 90
-  value: 3
 modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false

--- a/SlicerCART/src/utils/requirements.py
+++ b/SlicerCART/src/utils/requirements.py
@@ -6,6 +6,7 @@ import slicer
 import qt
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
+from vtkSegmentationCorePython import vtkSegment
 from glob import glob
 import re
 import time


### PR DESCRIPTION
This PR (fixes https://github.com/neuropoly/slicercart/issues/216) enables the module to work on the latest 3D Slicer version, 5.8.1: 
- In fact, segment names now have default name segment_1 in this version, so the naming of the labels must be redefined to load the segments properly;
- Segment IDs are now non-modifiable (in comparison to previous versions), which makes the necessity for the module to handle labels differently.
-  Adapt in the meantime the load latest classification segment editing in the viewer issues (see[ issue 190](https://github.com/neuropoly/slicercart/issues/190))
- Adds a re-ordering segment functions so it ensures that all labels are matching the configuration yaml file at the same of saving.