### PR TITLE
fixes an issue with undoing segmentation action

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -3372,37 +3372,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         Args:.
         """
-        if self.previousAction == 'segmentation':
-            self.segmentEditorWidget.undo()
+        #to update once measurement line is functional since this cannot remove markups
+        self.segmentEditorWidget.undo()
 
-        elif self.previousAction == 'markups':
-            # Get the last added markup node (or customize based on specific
-            # markup type)
-            markupsNodeList = slicer.mrmlScene.GetNodesByClass(
-                "vtkMRMLMarkupsNode")
-            markupsNodeList.InitTraversal()
-
-            lastMarkupNode = None
-
-            while True:
-                markupNode = markupsNodeList.GetNextItemAsObject()
-                if markupNode:
-                    lastMarkupNode = markupNode  # Keep track of the last
-                    # markup node
-                else:
-                    break
-
-            # Remove the last control point from the markup node (or remove the
-            # whole node if needed)
-            if lastMarkupNode and lastMarkupNode.GetNumberOfControlPoints() > 0:
-                lastMarkupNode.RemoveNthControlPoint(
-                    lastMarkupNode.GetNumberOfControlPoints() - 1)
-            else:
-                slicer.mrmlScene.RemoveNode(
-                    lastMarkupNode)  # Remove the whole markup node if no
-                # points remain
-
-            removedNode = self.lineDetails.pop(lastMarkupNode.GetName())
 
 
     @enter_function


### PR DESCRIPTION
previously considered markup (measurement line) and segmentation (painting) actions to undo action
now only considers segmentation due to faulty measurement line
related to #179 

