### PR TITLE
fixes issue #143 - data probe collapsible folds upon loading SlicerCART

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -285,6 +285,19 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.shortcut_objects = {}  # Maps shortcut key to QShortcut object
         self.shortcut_callbacks = {}
         self.set_keyboard_shortcuts()
+        
+        # Layout management on startup
+        # Closes Data Probe upon landing in SlicerCART
+        self.close_data_probe_on_startup()
+
+    @enter_function
+    def close_data_probe_on_startup(self):
+        mainWindow = slicer.util.mainWindow()
+        from ctk import ctkCollapsibleButton  # ensure CTK is imported
+        for widget in mainWindow.findChildren(ctkCollapsibleButton):
+            if widget.text == 'Data Probe':
+                widget.collapsed = True
+                Debug.print(self, "Data Probe collapsed")
 
     @enter_function
     def set_classification_version_labels(self, classif_label):
@@ -297,7 +310,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     @enter_function
     def visibilityModifiedCallback(self, caller, event):
         """
-        Each time segments visibility is changed, this function ic called.
+        Each time segments visibility is changed, this function is called.
         caller: used to get segment visibility
         event: segment modified
         """


### PR DESCRIPTION
**Previous behavior**
![image](https://github.com/user-attachments/assets/055ab564-8da7-4d98-9a57-feb5b83a223e)
This section, outside of the module, loads opened.

**Current behavior**
This section now loads collapsed. 

**Further improvement**
Figure out a way to have it collapsed on loading the entire application, regardless if SlicerCART is the default startup module. There is a way to control this, but has to do with source files. Will find the documentation soon. 
